### PR TITLE
don't break when using jest.restoreAllMocks()

### DIFF
--- a/__tests__/jest-built-ins.spec.js
+++ b/__tests__/jest-built-ins.spec.js
@@ -78,7 +78,6 @@ describe('jest built-ins', () => {
 		it('mockReset', () => {
 			expect(fetch.mockReset).toBeDefined();
 			fetch.mockReset();
-
 			expect(fetch.mock.calls.length).toEqual(0);
 			expect(fetch._calls.length).toEqual(0);
 			expect(fetch.routes.length).toEqual(0);

--- a/__tests__/regressions.spec.js
+++ b/__tests__/regressions.spec.js
@@ -1,0 +1,20 @@
+/*global jest */
+jest.mock('node-fetch', () => require('../server').sandbox());
+const fetch = require('node-fetch');
+
+describe('regressions and strange cases', () => {
+	it('works even when jest.resetAllMocks() is called', () => {
+		jest.resetAllMocks();
+		fetch.mock('*', 200);
+		fetch('http://example.com/path', 200);
+		expect(fetch).toHaveFetched('http://example.com/path');
+		fetch.reset();
+	});
+	it('works even when jest.clearAllMocks() is called', () => {
+		jest.clearAllMocks();
+		fetch.mock('*', 200);
+		fetch('http://example.com/path', 200);
+		expect(fetch).toHaveFetched('http://example.com/path');
+		fetch.reset();
+	});
+});


### PR DESCRIPTION
This adds some even more hideous mangling of jest mock functions in order to prevent `resetAllMocks()` from interferring with fetch mock