### PR TITLE
Move node-fetch from devDependencies to dependencies.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4459,8 +4459,7 @@
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-      "dev": true
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "homepage": "https://github.com/wheresrhys/fetch-mock-jest#readme",
   "dependencies": {
-    "fetch-mock": "^9.0.0"
+    "fetch-mock": "^9.0.0",
+    "node-fetch": "^2.6.0"
   },
   "devDependencies": {
     "eslint": "^6.6.0",
@@ -44,7 +45,6 @@
     "eslint-config-prettier": "^6.5.0",
     "eslint-plugin-prettier": "^3.1.1",
     "jest": "^25.0.0",
-    "node-fetch": "^2.6.0",
     "prettier": "^2.0.4"
   }
 }


### PR DESCRIPTION
I got an error copied below while trying to use `v1.3.0` this library. It turns out that `node-fetch` is currently only a `devDependency` in [`package.json`](https://github.com/wheresrhys/fetch-mock-jest/blob/master/package.json#L47). I'm using `pnpm` and it's strictness meant `node-fetch` wasn't available when `fetch-mock` (which has it as a peer dependency) required it. Moving the reference into `dependencies` in `fetch-mock-jest` fixes the issue (I have verified (and worked around) that with a `pnpmfile.js` entry) and I thought you might like a quick PR. :)

Many thanks for the library!

```
   Cannot find module 'node-fetch' from '../../node_modules/.pnpm/fetch-mock@9.10.7/node_modules/fetch-mock/cjs/server.js'       

    Require stack:
      C:/dev/src/bickleywallace-site/node_modules/.pnpm/fetch-mock@9.10.7/node_modules/fetch-mock/cjs/server.js
      C:/dev/src/bickleywallace-site/node_modules/.pnpm/fetch-mock-jest@1.3.0_jest@26.4.2/node_modules/fetch-mock-jest/server.js  
      src/utils/request.spec.ts

      at Resolver.resolveModule (../../node_modules/.pnpm/jest-resolve@26.4.0_jest-resolve@26.4.0/node_modules/jest-resolve/build/index.js:307:11)
      at Object.<anonymous> (../../node_modules/.pnpm/fetch-mock@9.10.7/node_modules/fetch-mock/cjs/server.js:9:10)
```