### PR TITLE
Adds node-fetch as an optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
   "peerDependencies": {
     "jest": "*"
   },
+  "optionalDependencies": {
+    "node-fetch": "*"
+  },
   "homepage": "https://github.com/wheresrhys/fetch-mock-jest#readme",
   "dependencies": {
     "fetch-mock": "^9.0.0"


### PR DESCRIPTION
This allows it to import node-fetch in a pnp / yarn berry environment

Otherwise this fails with an error like the following:

```
fetch-mock tried to access node-fetch (a peer dependency) but it isn't provided by its ancestors; this makes the require call ambiguous and unsound.
```

As an optionalDependency, and not a peerDependency, it does not have to be satisfied.