### PR TITLE
fix type definition of sandbox()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,6 @@ interface FetchMockJest {
   sandbox(): jest.MockInstance<Response, MockCall> & FetchMockSandbox;
 }
 
-declare const fetchMockJest: FetchMockJest & jest.MockInstance<Response, MockCall> & FetchMockStatic
+declare const fetchMockJest: FetchMockJest & jest.MockInstance<Response, MockCall> & Omit<FetchMockStatic, keyof FetchMockJest>
 
 export = fetchMockJest;


### PR DESCRIPTION
This fixes #34 by ensuring that the types of things on `FetchMockJest` override the ones provided by `FetchMockStatic`.